### PR TITLE
Fix: Configure downloader app for /downloader path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/downloader/src/App.tsx
+++ b/downloader/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename="/downloader">
         <Routes>
           <Route path="/" element={<Downloader />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}


### PR DESCRIPTION
The downloader application was not accessible under the /downloader URL path, resulting in a 'Page not found' error.

This was due to two main factors:
1. The React Router within the downloader app was not configured with a 'basename', causing it to misinterpret client-side routes.
2. Verification of the build process and Vercel routing rules was needed to ensure they align.

Changes made:
- Added `basename="/downloader"` to the `BrowserRouter` component in `downloader/src/App.tsx`. This ensures that client-side routing within the downloader app works correctly when served from the `/downloader` subpath.
- Verified that the Vite build process correctly outputs the downloader app to `dist/downloader/index.html`.
- Verified that the `vercel.json` rewrite rule `{ "source": "/downloader/:path*", "destination": "/downloader/index.html" }` correctly serves the downloader's `index.html` for requests to the `/downloader` path.

With these changes, the content of the `downloader` folder should now be correctly served and accessible at `tiktool.pro/downloader`.