### PR TITLE
Fix: Use relative paths for Vite inputs to resolve Vercel build error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,8 +20,8 @@ export default defineConfig(({ mode }) => ({
   build: {
     rollupOptions: {
       input: {
-        main: path.resolve(__dirname, "index.html"),
-        downloader: path.resolve(__dirname, "downloader/index.html"),
+        main: "index.html",
+        downloader: "downloader/index.html",
       },
     },
   },


### PR DESCRIPTION
The Vercel build was failing with the error:
'Could not resolve entry module "downloader/index.html"'

This commit changes the Vite configuration (`vite.config.ts`) to use direct relative paths for the Rollup input options (e.g., "index.html" and "downloader/index.html") instead of `path.resolve(__dirname, ...)`.

This change is intended to make path resolution more robust in Vercel's build environment. The local build process has been verified to work correctly with these updated paths.