### PR TITLE
Feat: Implement frontend call to cleanup API after video download

### DIFF
--- a/downloader/src/pages/Downloader.tsx
+++ b/downloader/src/pages/Downloader.tsx
@@ -78,6 +78,32 @@ const Downloader = () => {
       // Convert response to blob and download
       const blob = await response.blob();
       await downloadFile(blob, filename);
+
+      // Call cleanup API
+      if (filename && filename !== 'tiktok_video.mp4') { // Ensure filename is valid
+        try {
+          console.log(`Sending cleanup request for: ${filename}`);
+          const cleanupResponse = await fetch(`${BACKEND_URL}/cleanup/${filename}`, {
+            method: 'DELETE',
+          });
+          if (cleanupResponse.ok) {
+            console.log(`Cleanup successful for ${filename}`);
+            // Optionally, show a toast for successful cleanup if desired
+            // toast({ title: "Cleanup Successful", description: `${filename} removed from server.` });
+          } else {
+            const cleanupErrorData = await cleanupResponse.json().catch(() => ({ detail: 'Cleanup failed with non-JSON response' }));
+            console.warn(`Cleanup failed for ${filename}: ${cleanupErrorData.detail || cleanupResponse.statusText}`);
+            // Optionally, show a toast for failed cleanup if desired
+            // toast({ title: "Cleanup Failed", description: `Could not remove ${filename} from server: ${cleanupErrorData.detail || cleanupResponse.statusText}`, variant: "warning" });
+          }
+        } catch (cleanupError) {
+          console.error(`Error during cleanup call for ${filename}:`, cleanupError);
+          // Optionally, show a toast for error during cleanup
+          // toast({ title: "Cleanup Error", description: `An error occurred while trying to remove ${filename} from server.`, variant: "destructive" });
+        }
+      } else {
+        console.warn('Skipping cleanup: Filename is default or missing.');
+      }
       
       toast({
         title: "Download Complete",


### PR DESCRIPTION
This commit modifies the downloader page's frontend logic to send a cleanup request to the backend after a video download is successfully initiated.

Changes in `downloader/src/pages/Downloader.tsx`:
- In the `handleDownload` function, after the video file download is triggered using `downloadFile(blob, filename)`:
  - The `filename` is extracted from the `Content-Disposition` header of the download response.
  - A `DELETE` request is now made to the backend endpoint `${BACKEND_URL}/cleanup/${filename}`.
  - Console logs have been added to track the success or failure of this cleanup API call.

This change allows the backend to be notified to delete the temporary video file from the server shortly after you have started downloading it. Your experience for the primary download remains unchanged; cleanup errors are logged to the console.