### PR TITLE
Feat: Integrate Vercel Analytics

### DIFF
--- a/downloader/src/App.tsx
+++ b/downloader/src/App.tsx
@@ -1,4 +1,5 @@
 
+import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "@downloader/components/ui/toaster";
 import { Toaster as Sonner } from "@downloader/components/ui/sonner";
 import { TooltipProvider } from "@downloader/components/ui/tooltip";
@@ -14,6 +15,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <Analytics />
       <BrowserRouter basename="/downloader">
         <Routes>
           <Route path="/" element={<Downloader />} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.56.2",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
@@ -3164,6 +3165,43 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.56.2",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from "@vercel/analytics/react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -13,6 +14,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
+      <Analytics />
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />


### PR DESCRIPTION
This commit adds Vercel Analytics to the project to enable tracking of page views and other metrics provided by Vercel.

Changes:
1.  **Dependency Installation:**
    - Added `@vercel/analytics` as a project dependency.

2.  **Main Application (`src/App.tsx`):**
    - Imported `Analytics` from `@vercel/analytics/react`.
    - Included the `<Analytics />` component in the main application's JSX tree to enable analytics for the primary site.

3.  **Downloader Application (`downloader/src/App.tsx`):**
    - Imported `Analytics` from `@vercel/analytics/react`.
    - Included the `<Analytics />` component in the downloader application's JSX tree to enable analytics for the `/downloader` page.

After deployment, Vercel Analytics should start collecting data for both the main site and the downloader sub-page.